### PR TITLE
Verify downloaded binary with gpg and sha256sum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,13 @@ ENV VERSION=v5.7.0 NPM_VERSION=3
 # ENV CONFIG_FLAGS="--without-npm" RM_DIRS=/usr/include
 ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libgcc libstdc++" RM_DIRS=/usr/include
 
-RUN apk add --no-cache curl make gcc g++ binutils-gold python linux-headers paxctl libgcc libstdc++ && \
-  curl -sSL https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.gz | tar -xz && \
+RUN apk add --no-cache curl make gcc g++ binutils-gold python linux-headers paxctl libgcc libstdc++ gnupg && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D && \
+  curl -o node-${VERSION}.tar.gz -sSL https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.gz && \
+  curl -o SHASUMS256.txt.asc -sSL https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc && \
+  gpg --verify SHASUMS256.txt.asc && \
+  grep node-${VERSION}.tar.gz SHASUMS256.txt.asc | sha256sum -c - && \
+  tar -zxf node-${VERSION}.tar.gz && \
   cd /node-${VERSION} && \
   ./configure --prefix=/usr ${CONFIG_FLAGS} && \
   make -j$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache curl make gcc g++ binutils-gold python linux-headers paxc
     npm install -g npm@${NPM_VERSION} && \
     find /usr/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf; \
   fi && \
-  apk del curl make gcc g++ binutils-gold python linux-headers paxctl ${DEL_PKGS} && \
+  apk del curl make gcc g++ binutils-gold python linux-headers paxctl gnupg ${DEL_PKGS} && \
   rm -rf /etc/ssl /node-${VERSION} ${RM_DIRS} \
     /usr/share/man /tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp \
     /usr/lib/node_modules/npm/man /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apk add --no-cache curl make gcc g++ binutils-gold python linux-headers paxc
     find /usr/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf; \
   fi && \
   apk del curl make gcc g++ binutils-gold python linux-headers paxctl gnupg ${DEL_PKGS} && \
+  rm node-${VERSION}.tar.gz && \
   rm -rf /etc/ssl /node-${VERSION} ${RM_DIRS} \
     /usr/share/man /tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp \
     /usr/lib/node_modules/npm/man /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,14 @@ ENV VERSION=v5.7.0 NPM_VERSION=3
 ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libgcc libstdc++" RM_DIRS=/usr/include
 
 RUN apk add --no-cache curl make gcc g++ binutils-gold python linux-headers paxctl libgcc libstdc++ gnupg && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5 && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys 0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE44734EB7990E && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 && \
   gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 && \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys B9AE9905FFD7803F25714661B63B535A4C206CA9 && \
   curl -o node-${VERSION}.tar.gz -sSL https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.gz && \
   curl -o SHASUMS256.txt.asc -sSL https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc && \
   gpg --verify SHASUMS256.txt.asc && \


### PR DESCRIPTION
Hi,

Verify binary used in the build as described at https://github.com/nodejs/node

It's pretty straightforward, rather than download and unzip:

```
curl -sSL https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.gz | tar -xz && \
```

We add gnupg to the installed packages then download, verify and unzip:

```
  gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D && \
  curl -o node-${VERSION}.tar.gz -sSL https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.gz && \
  curl -o SHASUMS256.txt.asc -sSL https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc && \
  gpg --verify SHASUMS256.txt.asc && \
  grep node-${VERSION}.tar.gz SHASUMS256.txt.asc | sha256sum -c - && \
  tar -zxf node-${VERSION}.tar.gz && \
```

The rest of the build process is unchanged.

If any of the verify process fails the build will stop.

Here's a sample of the output added by the verify process (after package downloads and before ./configure)

```
...
...
Executing ca-certificates-20160104-r2.trigger
OK: 221 MiB in 57 packages
gpg: directory '/root/.gnupg' created
gpg: new configuration file '/root/.gnupg/dirmngr.conf' created
gpg: new configuration file '/root/.gnupg/gpg.conf' created
gpg: WARNING: options in '/root/.gnupg' are not yet active during this run
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 7D83545D: public key "Rod Vagg <rod@vagg.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Tue Feb 23 05:35:58 2016 UTC using RSA key ID 7D83545D
gpg: Good signature from "Rod Vagg <rod@vagg.org>" [unknown]
gpg:                 aka "Rod Vagg <r@va.gg>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: DD8F 2338 BAE7 501E 3DD5  AC78 C273 792F 7D83 545D
node-v5.7.0.tar.gz: OK
creating  ./icu_config.gypi
...
...
```

You can see a GPG warning, but it does check out OK.

Ideally Rod Vagg should get this key certified with a trusted signature, but for now this is as good as it gets.
