### PR TITLE
Have sha256sum output a status code instead of relying on grep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache curl make gcc g++ python linux-headers binutils-gold gnup
   done && \
   curl -sfSLO https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.xz && \
   curl -sfSL https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc | gpg --batch --decrypt | \
-    grep " node-${VERSION}.tar.xz\$" | sha256sum -c | grep . && \
+    grep " node-${VERSION}.tar.xz\$" | sha256sum -c | grep -E ': OK$' && \
   tar -xf node-${VERSION}.tar.xz && \
   cd node-${VERSION} && \
   ./configure --prefix=/usr ${CONFIG_FLAGS} && \


### PR DESCRIPTION
Alpine's `sha256sum` is capable of returning non-zero in the event a file is missing or a sum doesn't match. It's also a bit more imperative and clear than relying upon `grep .`, which in a few tests has provided a false positive (the following output is after breaking out the command into its own layer):

```
 ---> Running in a950fe894672
sha256sum: can't open 'node-v9.1.0.tar.xz': No such file or directory
node-v9.1.0.tar.xz: FAILED
gpg: Signature made Tue Nov  7 18:03:35 2017 UTC
gpg:                using RSA key 7434390BDBE9B9C5
gpg: Good signature from "Colin Ihrig <cjihrig@gmail.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 94AE 3667 5C46 4D64 BAFA  68DD 7434 390B DBE9 B9C5
sha256sum: WARNING: 1 of 1 computed checksums did NOT match
 ---> 26ba0a60ba38
Removing intermediate container a950fe894672
Successfully built 26ba0a60ba38
```

Which obviously should have aborted the build (`grep .` is seeing the single output of the `No such file or directory` and exiting zero).

This PR utilizes the `-s` (for s/tatus) and `-w` (for w/arn) in order to exit non-zero if the sums didn't match and to warn if the input is improperly formatted.